### PR TITLE
Update postgres-changes.mdx

### DIFF
--- a/apps/docs/content/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/content/guides/realtime/postgres-changes.mdx
@@ -1570,7 +1570,7 @@ supabase
         schema: 'public',
         table: 'colors',
         filter: PostgresChangeFilter(
-          type: PostgresChangeFilterType.lte,
+          type: PostgresChangeFilterType.inFilter,
           column: 'name',
           value: ['red', 'blue', 'yellow'],
         ),


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update - changed filter type in example code for dart language in the containing in list section

## What is the current behavior?

 #37169 , The filter type shown in the documentation is lte, The line: `value: ['red', 'blue', 'yellow'],` is not valid for lte because lte expects a single scalar value, not a list. If it runs, it will probably only use the first value ('red') or throw an error.
 
<img width="1080" height="773" alt="image" src="https://github.com/user-attachments/assets/e44a556e-2870-4e5d-98d6-d6b7c4c27596" />


## What is the new behavior?

The PostgresChangeFilterType is updated to inFilter to listen for changes where name equals any of 'red', 'blue', or 'yellow' matching the example given.

## Additional context

None.
